### PR TITLE
Debugging: Fix hanging when should unlock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-metamask",
-  "version": "1.0.7-dev",
+  "version": "1.0.7-debug",
   "main": "support/commands.js",
   "license": "MIT",
   "keywords": [

--- a/support/metamask.js
+++ b/support/metamask.js
@@ -291,6 +291,11 @@ module.exports = {
     await puppeteer.assignWindows();
     await puppeteer.metamaskWindow().waitForTimeout(1000);
     await puppeteer.metamaskWindow().bringToFront()
+
+    // debugging - to be removed
+    console.log('url: ',puppeteer.metamaskWindow().url());
+    console.log('element: ', await puppeteer.metamaskWindow().$(unlockPageElements.unlockPage))
+
     if (
       (await puppeteer.metamaskWindow().$(unlockPageElements.unlockPage)) ===
       null


### PR DESCRIPTION
When running multiple tests, the first test passes as it is able to setup metamask with the mnemonic and the password. On the second run, metamask should be on the unlock screen but it is failing the conditional check on setup and assumes the confirmation page.

This is only failing in a remote environment where visibility is limited.
